### PR TITLE
Added in a save image function.

### DIFF
--- a/src/rhizome/viz.clj
+++ b/src/rhizome/viz.clj
@@ -62,6 +62,15 @@
   (let [bytes (:out (sh/sh "dot" "-Tpng" :in s :out-enc :bytes))]
     (ImageIO/read (io/input-stream bytes))))
 
+(defn save-image
+  "Saves the given image buffer to the given filename. The default
+file type for the image is png, but an optional type may be supplied
+as a third argument."
+  ([filename image] 
+     (save-image filename "png" image))
+  ([filename filetype image] 
+     (ImageIO/write image filetype (io/file filename))))
+
 (def
   ^{:doc "Takes a graph descriptor in the style of `graph->dot`, and returns a rendered image."}
   graph->image


### PR DESCRIPTION
`save-image` was something I wanted to have. It's pretty simple and doesn't do anything too fancy. Thought I should offer this up in case you wanted it in rhizome proper.  
