### PR TITLE
Support record fields

### DIFF
--- a/test/rhizome/viz_test.clj
+++ b/test/rhizome/viz_test.clj
@@ -49,3 +49,13 @@
   
 
   )
+
+(deftest test-viz-record
+  (view-graph [:a :b [:a :x] [:a :y]]
+              {[:a :x] [:b]
+               :b [[:a :y] :a]}
+              :node->descriptor {:a {:label (array-map :x "x" :y "y")}
+                                 :b {:label "b"}}
+              :port? vector?
+              :port->pair identity)
+  (Thread/sleep pause))


### PR DESCRIPTION
This adds support for record fields: use a map as label, the keys will be mapped to port names.
To refer to a port, use a special kind of node that can be recognized with `port?`, and return a vector of the parent node and the port with `port->pair` when called with the port object. See: https://github.com/ztellman/rhizome/issues/5

Example:

``` clojure
  (view-graph [:a :b [:a :x] [:a :y]]
              {[:a :x] [:b]
               :b [[:a :y] :a]}
              :node->descriptor {:a {:label (array-map :x "x" :y "y")}
                                 :b {:label "b"}}
              :port? vector?
              :port->pair identity)
```

Here `:a` and `:b` are node objects; `[:a :x]` is a port object, referring to the `:x` field of node `:a`.
Multiple nodes may use `:x` as their port, it will always be used qualified with the node object.

Output: 
![screen shot 2014-05-15 at 21 31 45](https://cloud.githubusercontent.com/assets/77855/2990351/f7719c00-dc6f-11e3-8a7b-663b744a57a3.png)
