### PR TITLE
Added backslash to escapable characters

### DIFF
--- a/src/rhizome/dot.clj
+++ b/src/rhizome/dot.clj
@@ -3,7 +3,7 @@
 
 ;;;
 
-(def ^:private escapable-characters "|{}\"")
+(def ^:private escapable-characters "\\|{}\"")
 
 (defn- escape-string
   "Escape characters that are significant for the dot format."


### PR DESCRIPTION
Backslash characters in labels need to be escaped, otherwise labels with backslashes do not print properly, or in some cases, can even cause an error to be thrown.

This came up for a user of instaparse, which uses rhizome to display trees with label strings such as:

`"a\\tb"`

and

`"\"\\\"string\\\"\""`

Without including backslash among the escapable characters, the first example prints as `atb` and the second example throws an error.  Adding backslash fixes the problem.

(See https://github.com/Engelberg/instaparse/pull/89)