### PR TITLE
use a default of DPI 72

### DIFF
--- a/src/rhizome/viz.clj
+++ b/src/rhizome/viz.clj
@@ -102,7 +102,9 @@ as a third argument."
 (def
   ^{:doc "Takes a graph descriptor in the style of `graph->dot`, and returns SVG."}
   graph->svg
-  (comp dot->svg graph->dot))
+  (comp dot->svg
+        (fn [nodes adjacent & opts]
+          (graph->dot nodes adjacent (merge {:options {:dpi 72}} opts)))))
 
 (def
   ^{:doc "Takes a graph descriptor in the style of `graph->dot`, and displays a rendered image."}


### PR DESCRIPTION
This fixes a problem where SVG output could be cropped badly due to the way GraphViz handles DPI when dealing with path-based output formats. 

See https://github.com/ellson/graphviz/issues/27