### PR TITLE
Fixes a bug where graph->svg doesn't accept options

### DIFF
--- a/src/rhizome/viz.clj
+++ b/src/rhizome/viz.clj
@@ -152,8 +152,9 @@ as a third argument."
     :arglists (-> #'graph->dot meta :arglists)}
   graph->svg
   (comp dot->svg
-        (fn [nodes adjacent & opts]
-          (apply graph->dot nodes adjacent (apply concat (merge {:options {:dpi 72}} opts))))))
+        (fn [nodes adjacent & {:as opts}]
+          (let [final-opts (update-in opts [:options :dpi] #(if % % 72))]
+            (apply graph->dot nodes adjacent (apply concat final-opts))))))
 
 (def
   ^{:doc "Takes a graph descriptor in the style of `graph->dot`, and displays a rendered image."


### PR DESCRIPTION
The main problem is that `opts` is not a map and cannot be merged.
This was fixed with the small change from `& opts` to `& {:as opts}`.

I also made setting the default dpi a little more robust for the case
where `opts` has an `:options` map which has no `:dpi` key.